### PR TITLE
Added support for daemonsets

### DIFF
--- a/renderer.tsx
+++ b/renderer.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { Renderer } from "@k8slens/extensions";
 import { DeploymentMultiPodLogsMenu } from "./src/deployment-menu";
 import { StatefulSetMultiPodLogsMenu } from "./src/statefulset-menu";
+import { DaemonSetMultiPodLogsMenu } from "./src/daemonset-menu";
 
 type Deployment = Renderer.K8sApi.Deployment;
 type StatefulSet = Renderer.K8sApi.StatefulSet;
-
+type DaemonSet = Renderer.K8sApi.DaemonSet;
 /**
  *
  * RendererExtension which extends LensRendererExtension runs in Lens' 'renderer' process (NOT 'main' process)
@@ -37,6 +38,15 @@ export default class MultiPodLogsRenderer extends Renderer.LensExtension {
         MenuItem: (
           props: Renderer.Component.KubeObjectMenuProps<StatefulSet>
         ) => <StatefulSetMultiPodLogsMenu {...props} />,
+      },
+    },
+    {
+      kind: "DaemonSet",
+      apiVersions: ["apps/v1"],
+      components: {
+        MenuItem: (
+          props: Renderer.Component.KubeObjectMenuProps<DaemonSet>
+        ) => <DaemonSetMultiPodLogsMenu {...props} />,
       },
     },
   ];

--- a/src/daemonset-menu.tsx
+++ b/src/daemonset-menu.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { Renderer } from "@k8slens/extensions";
+import { MultiPodLogsCommon } from "./common";
+
+type DaemonSet = Renderer.K8sApi.DaemonSet;
+type Pod = Renderer.K8sApi.Pod;
+
+interface State {
+  pods: Pod[];
+  containerNames: Set<string>;
+}
+
+export class DaemonSetMultiPodLogsMenu extends React.Component<
+  Renderer.Component.KubeObjectMenuProps<DaemonSet>,
+  State
+> {
+  daemonset: DaemonSet;
+
+  protected dStore = Renderer.K8sApi.apiManager.getStore(
+    Renderer.K8sApi.daemonSetApi
+  ) as Renderer.K8sApi.DaemonSetStore;
+
+  constructor(props: Renderer.Component.KubeObjectMenuProps<DaemonSet>) {
+    super(props);
+    this.daemonset = props.object;
+    this.state = {
+      pods: [],
+      containerNames: new Set(),
+    };
+  }
+
+  async componentDidMount() {
+    // Get daemonset pods
+    const podList = this.dStore.getChildPods(this.daemonset);
+
+    // Get all containers from all pods
+    const containerNameList =
+      MultiPodLogsCommon.getContainersByPodList(podList);
+
+    // Update state
+    this.setState({
+      pods: podList,
+      containerNames: containerNameList,
+    });
+  }
+
+  render() {
+    const { containerNames } = this.state;
+
+    // Render menu item UI (and associate onClick action)
+    return MultiPodLogsCommon.uiMenu(
+      this.props,
+      containerNames,
+      this.daemonset.getNs(),
+      "daemonset",
+      this.daemonset.getName(),
+      "DaemonSet"
+    );
+  }
+}


### PR DESCRIPTION
The last remaining resource controller that was not covered yet are daemonsets. One of the most common deployment way of ingress-nginx is through daemonsets, so having menu entry to look for all the logs from ingress at the same time is certainly useful